### PR TITLE
creating symlink for airport for easy access

### DIFF
--- a/mac/99_mac_settings.sh
+++ b/mac/99_mac_settings.sh
@@ -51,5 +51,8 @@ rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 #Keep Mac from writing .DS_Store files to network drives.
 #defaults write com.apple.desktopservices DSDontWriteNetworkStores true
 
+# show wifi stats nearby, do `airport -s`
+sudo ln -s /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport /usr/sbin/airport
+
 echo "Reboot to apply KeyRepeat settings."
 echo " ------------------ DONE Applying macOS settings... --------------------"


### PR DESCRIPTION
simple wifi scanner
`airport -s`, example:

```
❯ airport -s                                                                                                                                                                                                 6 ↵
                            SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
                       NETGEAR07 10:0d:7f:ac:4d:ee -64  1       Y  -- WPA(PSK/AES/AES) WPA2(PSK/AES/AES)
                           Cisco 68:7f:74:d7:d1:72 -82  1       Y  -- WPA2(PSK/AES/AES)
                    netis_3673A7 e4:be:ed:36:73:a7 -87  1,+1    Y  -- WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                    Interzet@233 f8:f0:82:0b:ce:2b -86  1,+1    Y  RU WPA2(PSK/AES/AES)
                         Default 00:17:9a:72:a3:cc -74  4       Y  RU WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                         Default 00:17:9a:72:1f:84 -86  2       N  RU WPA(PSK/TKIP/TKIP)
                         dlink86 14:d6:4d:37:6e:68 -85  7       Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                     Imaginarium 50:64:2b:b4:9c:95 -80  10      Y  CN WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                            DIVP 74:da:da:1d:fe:d0 -86  9,+1    Y  -- WPA2(PSK/AES/AES)
                        Svetlana 14:cc:20:9f:94:a4 -90  10,-1   Y  -- WPA2(PSK/AES/AES)
                   Keenetic-6269 28:28:5d:d9:fb:74 -84  11      Y  RU WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                       Sokolov5G 74:9d:79:57:e6:4c -88  52      Y  #a WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
                 TP-Link_C383_5G b0:4e:26:19:c3:82 -84  36      Y  NO WPA2(PSK/AES/AES)
                      Natalia_5G 64:ee:b7:16:b3:60 -37  153     Y  US WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                      Wive-NG-MT f8:f0:82:b8:de:11 -78  5,+1    Y  RU WPA2(PSK/AES/AES)
                       svir-rout 1c:5f:2b:5d:c1:0b -74  5       Y  -- WPA(PSK/AES/AES) WPA2(PSK/AES/AES)
                    At-HoMe WiFi ec:08:6b:7e:b8:7a -68  5,+1    Y  -- WPA2(PSK/AES,TKIP/TKIP)
                         49_2014 00:04:56:ca:3b:e3 -73  2       Y  OT WPA2(PSK/AES/AES)
                             qsc b0:be:76:7f:51:5c -45  3,+1    Y  -- WPA2(PSK/AES/AES)
                        Aristarh 90:e6:ba:74:32:20 -81  1       N  -- WPA(PSK/TKIP/TKIP)
                    interzet@232 10:fe:ed:c8:8a:a6 -83  1,+1    Y  -- WPA2(PSK/AES/AES)
                        skynet30 00:72:63:1a:c9:55 -88  1,+1    Y  -- WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
                      segatelega 00:1e:58:20:09:8c -88  13      N  RU WPA(PSK/TKIP/TKIP)
                    DIR-615T-208 28:3b:82:4e:21:39 -82  13,-1   Y  -- WPA2(PSK/AES/AES)
                        Smilodon e4:6f:13:0d:23:62 -69  13      Y  -- WPA2(PSK/AES/AES)
            Sosed_S_perfom_mudak c0:4a:00:3c:04:be -84  11,-1   Y  -- WPA2(PSK/AES/AES)
                    TP-Link_C383 b0:4e:26:19:c3:83 -68  11,-1   Y  -- WPA2(PSK/AES/AES)
                        WiFi-231 c0:4a:00:e2:e3:3c -41  11      Y  RU WPA(PSK/AES/AES) WPA2(PSK/AES/AES)
                         komonya e0:24:7f:26:6f:a4 -88  9       Y  CN WPA2(PSK/AES/AES)
                            WiFi 28:28:5d:d8:c8:b6 -79  9,+1    Y  RU WPA2(PSK/AES/AES)
                    Lovely Place e4:18:6b:5a:ca:be -67  8       Y  RU WPA2(PSK/AES/AES)
                         Home154 60:e3:27:61:d2:ee -82  7,-1    Y  -- WPA(PSK/AES/AES) WPA2(PSK/AES/AES)
                        Seal_spb 14:da:e9:db:2d:84 -76  7       Y  -- WPA(PSK/TKIP/TKIP)
                            ASUS 60:a4:4c:d0:c3:7c -80  6       Y  -- WPA2(PSK/AES/AES)
                         Natalia 64:ee:b7:16:b3:5b -36  6,+1    Y  -- WPA(PSK/TKIP,AES/TKIP) WPA2(PSK/TKIP,AES/TKIP)
```